### PR TITLE
remove 'dp' string on strokeWidth

### DIFF
--- a/svg2vectordrawable.js
+++ b/svg2vectordrawable.js
@@ -337,7 +337,7 @@ function svg2vectorDrawableContent(svgContent, density) {
 
                     if(stroke !== '' && stroke !== 'none') {
                         if (strokeWidth === '') {
-                            vectorDrawableXML += repeatString(' ', indent) + '    android:strokeWidth="1dp"\n';
+                            vectorDrawableXML += repeatString(' ', indent) + '    android:strokeWidth="1"\n';
                         } else {
                             vectorDrawableXML += repeatString(' ', indent) + '    android:strokeWidth="' + strokeWidth + '"\n';
                         }


### PR DESCRIPTION
(Regarding #2 )

In `if (strokeWidth === '')`, the declare of that strokeWidth contains unit `dp` but otherwise `strokeWidth` has no unit, so I'm guessing `dp` is not intended to be there