### PR TITLE
Fix inclusion of xmlns:aapt

### DIFF
--- a/lib/svg2vectordrawable.js
+++ b/lib/svg2vectordrawable.js
@@ -60,6 +60,7 @@ let JS2XML = function() {
         'android:fillType', // fill-rule For SDK 24+, evenOdd, nonZero. Default is nonZero.
         // aapt
         'name',
+        'xmlns:aapt',
         // gradient
         'android:type', // linear, radial, sweep
         'android:startX', // x1
@@ -261,7 +262,7 @@ JS2XML.prototype.refactorData = function(data) {
         }
         elemSVG.attrs = {};
         // SVG is not support sweep (angular) gradient
-        if (data.querySelector('linearGradient, radialGradient, sweepGradient')) {
+        if (data.querySelector("linearGradient, radialGradient, sweepGradient, aapt\\:attr")) {
             elemSVG.addAttr({ name: 'xmlns:aapt', value: 'http://schemas.android.com/aapt', prefix: 'xmlns', local: 'aapt' });
         }
         elemSVG.addAttr({ name: 'android:width', value: this.width + 'dp', prefix: 'android', local: 'width' });


### PR DESCRIPTION
In some cases, the tool was not including `xmlns:aapt` even though it was being used within the output file.

Given this SVG:

```
<svg xmlns="http://www.w3.org/2000/svg" width="266" height="99" viewBox="0 0 266 99">
    <defs>
        <linearGradient id="a" x1="92.452%" x2="0%" y1="100%" y2="0%">
            <stop offset="0%" stop-color="#B1E9FF"/>
            <stop offset="100%" stop-color="#77D9FF"/>
        </linearGradient>
    </defs>
    <g fill="none" fill-rule="evenodd">
        <path fill="url(#a)" d="M59 82l-8.5 17L42 82H2a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2h262a2 2 0 0 1 2 2v78a2 2 0 0 1-2 2H59z"/>
        <path fill="#FFF" d="M38.321 63v-4.75a4.212 4.212 0 0 0-2.55-3.86C30.024 51.9 26 46.068 26 39.34 26 30.37 33.149 23 42 23c8.854 0 16 7.37 16 16.34C58 49.923 49.983 59.926 38.321 63M42 15c-13.277 0-24 10.827-24 24s10.723 24 24 24 24-10.827 24-24-10.723-24-24-24"/>
    </g>
</svg>
```

Before this patch, converting it yields:

```
<vector xmlns:android="http://schemas.android.com/apk/res/android"
    android:width="266dp"
    android:height="99dp"
    android:viewportWidth="266"
    android:viewportHeight="99">
    <path
        android:fillType="evenOdd"
        android:pathData="M59 82l-8.5 17L42 82H2a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2h262a2 2 0 0 1 2 2v78a2 2 0 0 1-2 2H59z">
        <aapt:attr name="android:fillColor">
            <gradient
                android:type="linear"
                android:startX="245.92"
                android:startY="99"
                android:endX="0"
                android:endY="0">
                <item
                    android:color="#B1E9FF"
                    android:offset="0"/>
                <item
                    android:color="#77D9FF"
                    android:offset="1"/>
            </gradient>
        </aapt:attr>
    </path>
    <path
        android:fillColor="#FFFFFF"
        android:fillType="evenOdd"
        android:pathData="M38.32 63v-4.75a4.21 4.21 0 0 0-2.55-3.86A16.39 16.39 0 0 1 26 39.34C26 30.37 33.15 23 42 23s16 7.37 16 16.34C58 49.92 49.98 59.93 38.32 63M42 15c-13.28 0-24 10.83-24 24s10.72 24 24 24 24-10.83 24-24-10.72-24-24-24"/>
</vector>
```

Note that it doesn't add the `xmlns:aapt` attribute to the root.

After this patch:

```
<vector xmlns:android="http://schemas.android.com/apk/res/android"
    xmlns:aapt="http://schemas.android.com/aapt"
    android:width="266dp"
    android:height="99dp"
    android:viewportWidth="266"
    android:viewportHeight="99">
    <path
        android:fillType="evenOdd"
        android:pathData="M59 82l-8.5 17L42 82H2a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2h262a2 2 0 0 1 2 2v78a2 2 0 0 1-2 2H59z">
        <aapt:attr name="android:fillColor">
            <gradient
                android:type="linear"
                android:startX="245.92"
                android:startY="99"
                android:endX="0"
                android:endY="0">
                <item
                    android:color="#B1E9FF"
                    android:offset="0"/>
                <item
                    android:color="#77D9FF"
                    android:offset="1"/>
            </gradient>
        </aapt:attr>
    </path>
    <path
        android:fillColor="#FFFFFF"
        android:fillType="evenOdd"
        android:pathData="M38.32 63v-4.75a4.21 4.21 0 0 0-2.55-3.86A16.39 16.39 0 0 1 26 39.34C26 30.37 33.15 23 42 23s16 7.37 16 16.34C58 49.92 49.98 59.93 38.32 63M42 15c-13.28 0-24 10.83-24 24s10.72 24 24 24 24-10.83 24-24-10.72-24-24-24"/>
</vector>
```