### PR TITLE
fixed evaluation of rx/ry for rounded rectangle conversion to path

### DIFF
--- a/lib/svg2vectordrawable.js
+++ b/lib/svg2vectordrawable.js
@@ -281,8 +281,17 @@ JS2XML.prototype.refactorData = function(data) {
             let y = elem.hasAttr('y') ? parseFloat(elem.attr('y').value) : 0;
             let width = elem.hasAttr('width') ? parseFloat(elem.attr('width').value) : 0;
             let height = elem.hasAttr('height') ? parseFloat(elem.attr('height').value) : 0;
-            let rx = elem.hasAttr('rx') ? parseFloat(elem.attr('rx').value) : 0;
-            let ry = elem.hasAttr('ry') ? parseFloat(elem.attr('ry').value) : 0;
+            let rx, ry;
+            if (elem.hasAttr('rx') && elem.hasAttr('ry')) { // see spec here: https://www.w3.org/TR/SVG11/shapes.html#RectElement
+                rx = parseFloat(elem.attr('rx').value);
+                ry = parseFloat(elem.attr('ry').value);
+            } else if (elem.hasAttr('rx')) {
+                rx = parseFloat(elem.attr('rx').value);
+                ry = rx;
+            } else if (elem.hasAttr('ry')) {
+                ry = parseFloat(elem.attr('ry').value);
+                rx = ry;
+            }
             let pathData = this.rectToPathData(x, y, width, height, rx, ry);
             elem.addAttr({ name: 'd', value: pathData, prefix: '', local: 'd' });
         });


### PR DESCRIPTION
According to the specs, the attributes `rx` and `ry` of a rectangle can be both specified (this will result in rounded corners) or both not specified (square corners). But when only one of them is specified, this logic applies:
> Otherwise, if a properly specified value is provided for ‘rx’, but not for ‘ry’, then set both rx and ry to the value of ‘rx’.
> Otherwise, if a properly specified value is provided for ‘ry’, but not for ‘rx’, then set both rx and ry to the value of ‘ry’.
[source: https://www.w3.org/TR/SVG11/shapes.html#RectElement]

In the function `refactorData` the code that calculates the values for rx/rx is doing it independently:
```
let rx = elem.hasAttr('rx') ? parseFloat(elem.attr('rx').value) : 0;
let ry = elem.hasAttr('ry') ? parseFloat(elem.attr('ry').value) : 0;
```
but actually if one is not specified, it acquires the value of the other.

When using Sketch to export a simple shape (a rectangle with a border radius applied) 
<img width="113" alt="screenshot_1965" src="https://user-images.githubusercontent.com/686239/47752447-630b0980-dc8c-11e8-854c-8eebc62c86ab.png">

this is the generated SVG (as you can see the rectangle has only `rx` specified):
```
<svg width="100" height="100" viewBox="0 0 100 100">
    <rect width="100" height="100" rx="20" fill="#FF0000" fill-rule="evenodd"/>
</svg>
```

If I use svg2vectordrawable to generate the <vector> and import it in Android Studio, this is the result:
<img width="1108" alt="screenshot_1967" src="https://user-images.githubusercontent.com/686239/47752589-c7c66400-dc8c-11e8-873e-f6f1eafd5f4f.png">

If I apply the proposed change to the code, and re-generate the <vector>, this is the result:
<img width="1107" alt="screenshot_1968" src="https://user-images.githubusercontent.com/686239/47752844-83879380-dc8d-11e8-9b14-f564f291f48a.png">
