### PR TITLE
Add TypeScript declaration

### DIFF
--- a/lib/svg-to-vectordrawable.d.ts
+++ b/lib/svg-to-vectordrawable.d.ts
@@ -1,0 +1,6 @@
+declare function svg2vectordrawable(
+  svgCode: string,
+  floatPrecision?: number
+): Promise<string>;
+
+export = svg2vectordrawable;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "homepage": "https://github.com/Ashung/svg2vectordrawable",
   "license": "MIT",
   "main": "./lib/svg-to-vectordrawable.js",
+  "types": "./lib/svg-to-vectordrawable.d.ts",
   "bin": {
     "s2v": "./bin/svg2vectordrawable",
     "svg2avd": "./bin/svg2vectordrawable",


### PR DESCRIPTION
Thanks for the nice library. I'm planning on using the library in a TypeScript codebase, and would like to provide [TypeScript declarations](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html) for the library.

It is usually preferred to keep the type definitions in the library packages themselves, so that the types better match the implementation. So I'm here proposing to add them to the project codebase, if that is okay by you in this case. Alternatively, I can publish the type declarations through the https://definitelytyped.org project.