### PR TITLE
Handle rect masks

### DIFF
--- a/lib/svg-to-vectordrawable.js
+++ b/lib/svg-to-vectordrawable.js
@@ -271,60 +271,6 @@ JS2XML.prototype.refactorData = function(data, floatPrecision) {
         });
     }
 
-
-    // Tag mask to clip-path
-    let elemMasks = data.querySelectorAll('mask');
-    if (elemMasks) {
-        elemMasks.forEach(elem => {
-            if (elem.hasAttr('id')) {
-                let maskId = elem.attr('id').value;
-                let clipMaskElem = elem.content[0];
-                let maskedElems = data.querySelectorAll(`*[mask="url(#${maskId})"]`);
-                let pathData = clipMaskElem.attr('d').value;
-                // Create a group for mask
-                let maskGroup = new JSAPI({ elem: 'group', attrs: {}, content: [] });
-                clipMaskElem.renameElem('clip-path');
-                clipMaskElem.attrs = {};
-                clipMaskElem.addAttr({ name: 'android:pathData', value: pathData, prefix: 'android', local: 'pathData' });
-                maskGroup.content.push(clipMaskElem);
-                // Move masked layer to mask group
-                maskedElems.forEach(item => {
-                    item.removeAttr('mask');
-                    maskGroup.content.push(item);
-                });
-                elem.parentNode.spliceContent(elem.parentNode.content.indexOf(maskedElems[0]), maskedElems.length, maskGroup);
-            }
-        });
-    }
-
-    // Tag svg to vector
-    let elemSVG = data.querySelector('svg');
-    if (elemSVG) {
-        elemSVG.renameElem('vector');
-        if (elemSVG.hasAttr('width') && elemSVG.hasAttr('height')) {
-            this.width = parseInt(elemSVG.attr('width').value);
-            this.height = parseInt(elemSVG.attr('height').value);
-        }
-        if (elemSVG.hasAttr('viewBox')) {
-            let [x, y, w, h] = elemSVG.attr('viewBox').value.split(/\s+/);
-            this.viewportWidth = w;
-            this.viewportHeight = h;
-            if (!elemSVG.hasAttr('width') && !elemSVG.hasAttr('height')) {
-                this.width = w;
-                this.height = h;
-            }
-        }
-        elemSVG.attrs = {};
-        // SVG is not support sweep (angular) gradient
-        if (data.querySelector("linearGradient, radialGradient, sweepGradient, aapt\\:attr")) {
-            elemSVG.addAttr({ name: 'xmlns:aapt', value: 'http://schemas.android.com/aapt', prefix: 'xmlns', local: 'aapt' });
-        }
-        elemSVG.addAttr({ name: 'android:width', value: this.width + 'dp', prefix: 'android', local: 'width' });
-        elemSVG.addAttr({ name: 'android:height', value: this.height + 'dp', prefix: 'android', local: 'height' });
-        elemSVG.addAttr({ name: 'android:viewportWidth', value: this.viewportWidth, prefix: 'android', local: 'viewportWidth' });
-        elemSVG.addAttr({ name: 'android:viewportHeight', value: this.viewportHeight, prefix: 'android', local: 'viewportHeight' });
-    }
-
     // Rounded rect to path, SVGO does not convert round rect to paths.
     let elemRects = data.querySelectorAll('rect');
     if (elemRects) {
@@ -391,6 +337,59 @@ JS2XML.prototype.refactorData = function(data, floatPrecision) {
             }
             elem.addAttr({ name: 'd', value: pathData, prefix: '', local: 'd' });
         });
+    }
+
+    // Tag mask to clip-path
+    let elemMasks = data.querySelectorAll('mask');
+    if (elemMasks) {
+        elemMasks.forEach(elem => {
+            if (elem.hasAttr('id')) {
+                let maskId = elem.attr('id').value;
+                let clipMaskElem = elem.content[0];
+                let maskedElems = data.querySelectorAll(`*[mask="url(#${maskId})"]`);
+                let pathData = clipMaskElem.attr('d').value;
+                // Create a group for mask
+                let maskGroup = new JSAPI({ elem: 'group', attrs: {}, content: [] });
+                clipMaskElem.renameElem('clip-path');
+                clipMaskElem.attrs = {};
+                clipMaskElem.addAttr({ name: 'android:pathData', value: pathData, prefix: 'android', local: 'pathData' });
+                maskGroup.content.push(clipMaskElem);
+                // Move masked layer to mask group
+                maskedElems.forEach(item => {
+                    item.removeAttr('mask');
+                    maskGroup.content.push(item);
+                });
+                elem.parentNode.spliceContent(elem.parentNode.content.indexOf(maskedElems[0]), maskedElems.length, maskGroup);
+            }
+        });
+    }
+
+    // Tag svg to vector
+    let elemSVG = data.querySelector('svg');
+    if (elemSVG) {
+        elemSVG.renameElem('vector');
+        if (elemSVG.hasAttr('width') && elemSVG.hasAttr('height')) {
+            this.width = parseInt(elemSVG.attr('width').value);
+            this.height = parseInt(elemSVG.attr('height').value);
+        }
+        if (elemSVG.hasAttr('viewBox')) {
+            let [x, y, w, h] = elemSVG.attr('viewBox').value.split(/\s+/);
+            this.viewportWidth = w;
+            this.viewportHeight = h;
+            if (!elemSVG.hasAttr('width') && !elemSVG.hasAttr('height')) {
+                this.width = w;
+                this.height = h;
+            }
+        }
+        elemSVG.attrs = {};
+        // SVG is not support sweep (angular) gradient
+        if (data.querySelector("linearGradient, radialGradient, sweepGradient, aapt\\:attr")) {
+            elemSVG.addAttr({ name: 'xmlns:aapt', value: 'http://schemas.android.com/aapt', prefix: 'xmlns', local: 'aapt' });
+        }
+        elemSVG.addAttr({ name: 'android:width', value: this.width + 'dp', prefix: 'android', local: 'width' });
+        elemSVG.addAttr({ name: 'android:height', value: this.height + 'dp', prefix: 'android', local: 'height' });
+        elemSVG.addAttr({ name: 'android:viewportWidth', value: this.viewportWidth, prefix: 'android', local: 'viewportWidth' });
+        elemSVG.addAttr({ name: 'android:viewportHeight', value: this.viewportHeight, prefix: 'android', local: 'viewportHeight' });
     }
 
     // Tag path

--- a/test/svgo-to-vectordrawable-test.js
+++ b/test/svgo-to-vectordrawable-test.js
@@ -67,4 +67,19 @@ describe('svg-to-vectordrawable', function() {
             `);
         });
     });
+
+    describe('Hanldes rect as masks.', () => {
+        it('Does not reject', async () => {
+            await svg2vectordrawable(`
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <mask id="mask0" mask-type="alpha" maskUnits="userSpaceOnUse" x="2" y="2" width="20" height="20">
+                        <rect x="2" y="2" width="20" height="20" rx="4" fill="#000000"/>
+                    </mask>
+                    <g mask="url(#mask0)">
+                        <path d="M 0 0 L 24 0 L 24 24 L 0 24" fill="#000000" />
+                    </g>
+                </svg>
+            `);
+        });
+    });
 });


### PR DESCRIPTION
Rect masks produce exception:
```
1) svg-to-vectordrawable Hanldes rect as masks. Does not reject
  Message:
    TypeError: Cannot read property 'value' of undefined
  Stack:
        at <Jasmine>
        at elemMasks.forEach.elem (svg2vectordrawable/lib/svg-to-vectordrawable.js:283:54)
        at <Jasmine>
        at JS2XML.refactorData (svg2vectordrawable/lib/svg-to-vectordrawable.js:278:19)
        at JS2XML.convert (svg2vectordrawable/lib/svg-to-vectordrawable.js:641:10)
        at data (svg2vectordrawable/lib/svg-to-vectordrawable.js:778:40)
        at SAXParser.sax.onend (svg2vectordrawable/node_modules/svgo/lib/svgo/svg2js.js:169:13)
        at emit (svg2vectordrawable/node_modules/sax/lib/sax.js:624:35)
        at end (svg2vectordrawable/node_modules/sax/lib/sax.js:667:5)
        at SAXParser.write (svg2vectordrawable/node_modules/sax/lib/sax.js:975:14)
        at SAXParser.close (svg2vectordrawable/node_modules/sax/lib/sax.js:157:38)
```

We need transform rects to paths before handling masks.