### PR TITLE
Fill paths with black if 'fillBlack' flag is used.

### DIFF
--- a/lib/svg-to-vectordrawable.d.ts
+++ b/lib/svg-to-vectordrawable.d.ts
@@ -1,7 +1,8 @@
 declare function svg2vectordrawable(
   svgCode: string,
   floatPrecision?: number,
-  strict?: boolean
+  strict?: boolean,
+  fillBlack?: boolean,
 ): Promise<string>;
 
 export = svg2vectordrawable;

--- a/lib/svg-to-vectordrawable.js
+++ b/lib/svg-to-vectordrawable.js
@@ -85,7 +85,7 @@ let JS2XML = function() {
     ];
 };
 
-JS2XML.prototype.refactorData = function(data, floatPrecision) {
+JS2XML.prototype.refactorData = function(data, floatPrecision, fillBlack) { 
 
     // Tag use to original
     let elemUses = data.querySelectorAll('use');
@@ -409,6 +409,12 @@ JS2XML.prototype.refactorData = function(data, floatPrecision) {
                     elem.removeAttr('fill');
                 }
             }
+            // Fill black?
+            else if (fillBlack) {
+                let fillAttr = { name: 'android:fillColor', value: "#000", prefix: 'android', local: 'fillColor' };
+                elem.addAttr(fillAttr);
+            }
+
             // Opacity, Android not support path/group alpha
             if (elem.hasAttr('opacity')) {
                 elem.addAttr({ name: 'android:fillAlpha', value: elem.attr('opacity').value, prefix: 'android', local: 'fillAlpha' });
@@ -636,8 +642,8 @@ JS2XML.prototype.round = function(value, floatPrecision) {
     return Math.round(value * Math.pow(10, floatPrecision)) / Math.pow(10, floatPrecision);
 };
 
-JS2XML.prototype.convert = function(data, floatPrecision, strict) {
-    this.refactorData(data, floatPrecision);
+JS2XML.prototype.convert = function(data, floatPrecision, strict, fillBlack) {
+    this.refactorData(data, floatPrecision, fillBlack);
     return this.travelConvert(data, strict);
 };
 
@@ -762,9 +768,10 @@ JS2XML.prototype.rectToPathData = function(x, y, width, height, rx, ry) {
  * @param {String} svgCode SVG code
  * @param {Number} floatPrecision Integer number
  * @param {Boolean} strict Set strict mode
+ * @param {Boolean} fillBlack Add black fill to paths with no fill
  * @returns {Promise<string>}
  */
-module.exports = function(svgCode, floatPrecision, strict) {
+module.exports = function(svgCode, floatPrecision, strict, fillBlack) {
     if (floatPrecision === undefined) {
         floatPrecision = 2;
     }
@@ -774,7 +781,7 @@ module.exports = function(svgCode, floatPrecision, strict) {
                reject(data.error);
             }
             else {
-                let xml = new JS2XML().convert(data, floatPrecision, strict);
+                let xml = new JS2XML().convert(data, floatPrecision, strict, fillBlack);
                 resolve(xml);
             }
         });

--- a/test/svgo-to-vectordrawable-test.js
+++ b/test/svgo-to-vectordrawable-test.js
@@ -52,6 +52,44 @@ describe('svg-to-vectordrawable', function() {
         `);
     });
 
+    it(`Flag 'fillBlack' uses black fill for paths with no fill.`, async () => {
+        // Flag
+        await svg2vectordrawable(`
+            <svg width="24" height="24" viewBox="0 0 24 24">
+                <path d="M5 5h5v5H5z"/>
+            </svg>
+        `, 
+        undefined, 
+        undefined, 
+        true, // blackDefault
+        ).then(function(vd) { expect(vd).toEqual(
+            '<vector xmlns:android="http://schemas.android.com/apk/res/android"\n' +
+            '    android:width="24dp"\n' +
+            '    android:height="24dp"\n' +
+            '    android:viewportWidth="24"\n' +
+            '    android:viewportHeight="24">\n' +
+            '    <path\n' + 
+            '        android:fillColor="#000"\n' +  
+            '        android:pathData="M5 5h5v5H5z"/>\n' +
+            '</vector>\n')});
+
+        // No flag
+        await svg2vectordrawable(`
+            <svg width="24" height="24" viewBox="0 0 24 24">
+                <path d="M5 5h5v5H5z"/>
+            </svg>
+        `).then(function(vd) { expect(vd).toEqual(
+            '<vector xmlns:android="http://schemas.android.com/apk/res/android"\n' +
+            '    android:width="24dp"\n' +
+            '    android:height="24dp"\n' +
+            '    android:viewportWidth="24"\n' +
+            '    android:viewportHeight="24">\n' +
+            '    <path\n' +  
+            '        android:pathData="M5 5h5v5H5z"/>\n' +
+            '</vector>\n')});
+    });
+
+
     describe('Stop offset default value support', () => {
         it('Does not throw', async () => {
             await svg2vectordrawable(`


### PR DESCRIPTION
Problem:
An SVG that renders as solid black in a web browser renders with no fill after being converted to vector drawable. 

As per SVG spec:
https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill