### PR TITLE
Apply group attributes to rounded rectangles

### DIFF
--- a/lib/svg-to-vectordrawable.js
+++ b/lib/svg-to-vectordrawable.js
@@ -85,7 +85,7 @@ let JS2XML = function() {
     ];
 };
 
-JS2XML.prototype.refactorData = function(data, floatPrecision, fillBlack) { 
+JS2XML.prototype.refactorData = function(data, floatPrecision, fillBlack) {
 
     // Tag use to original
     let elemUses = data.querySelectorAll('use');
@@ -145,6 +145,74 @@ JS2XML.prototype.refactorData = function(data, floatPrecision, fillBlack) {
                     elem.addAttr({ name: attr.name.substr(1), value: attr.value, prefix: '', local: attr.name.substr(1) });
                 }
             }, this);
+        });
+    }
+
+    // Rounded rect to path, SVGO does not convert round rect to paths.
+    let elemRects = data.querySelectorAll('rect');
+    if (elemRects) {
+        elemRects.forEach(elem => {
+            elem.renameElem('path');
+            let x = elem.hasAttr('x') ? parseFloat(elem.attr('x').value) : 0;
+            let y = elem.hasAttr('y') ? parseFloat(elem.attr('y').value) : 0;
+            let width = elem.hasAttr('width') ? parseFloat(elem.attr('width').value) : 0;
+            let height = elem.hasAttr('height') ? parseFloat(elem.attr('height').value) : 0;
+            let rx = 0;
+            let ry = 0;
+            // see spec here: https://www.w3.org/TR/SVG11/shapes.html#RectElement
+            if (elem.hasAttr('rx') && elem.hasAttr('ry')) {
+                rx = parseFloat(elem.attr('rx').value);
+                ry = parseFloat(elem.attr('ry').value);
+            }
+            else if (elem.hasAttr('rx')) {
+                rx = parseFloat(elem.attr('rx').value);
+                ry = rx;
+            }
+            else if (elem.hasAttr('ry')) {
+                ry = parseFloat(elem.attr('ry').value);
+                rx = ry;
+            }
+            x = this.round(x, floatPrecision);
+            y = this.round(y, floatPrecision);
+            width = this.round(width, floatPrecision);
+            height = this.round(height, floatPrecision);
+            rx = this.round(rx, floatPrecision);
+            ry = this.round(ry, floatPrecision);
+            let pathData = this.rectToPathData(x, y, width, height, rx, ry);
+            // Android 8- have a bug when drawing rounded rectangle with arc code in path data.
+            if (rx !== 0 || ry !== 0) {
+                pathData = svgpath(pathData).unarc().rel().round(floatPrecision).toString();
+            }
+
+            // Apply transform to rect.
+            if (elem.hasAttr('transform')) {
+                let svgTransform = elem.attr('transform').value;
+                let number = '((?:-)?\\d+(?:\\.\\d+)?)';
+                let separator = '(?:(?:\\s+)|(?:\\s*,\\s*))';
+                let translateRegExp = new RegExp(`translate\\(${number}${separator}?${number}?\\)`);
+                let scaleRegExp = new RegExp(`scale\\(${number}${separator}?${number}?\\)`);
+                let rotateRegExp = new RegExp(`rotate\\(${number}${separator}?${number}?${separator}?${number}?\\)`);
+                let translateMatch = translateRegExp.exec(svgTransform);
+                let scaleMatch = scaleRegExp.exec(svgTransform);
+                let rotateMatch = rotateRegExp.exec(svgTransform);
+                if (rotateMatch) {
+                    let angle = parseFloat(rotateMatch[1]);
+                    let rx = parseFloat(rotateMatch[2]) || 0;
+                    let ry = parseFloat(rotateMatch[3]) || 0;
+                    pathData = svgpath(pathData).rotate(angle, rx, ry).round(floatPrecision).toString();
+                }
+                if (scaleMatch) {
+                    let sx = parseFloat(scaleMatch[1]);
+                    let sy = parseFloat(scaleMatch[2]) || sx;
+                    pathData = svgpath(pathData).scale(sx, sy).round(floatPrecision).toString();
+                }
+                if (translateMatch) {
+                    let x = parseFloat(translateMatch[1]);
+                    let y = parseFloat(translateMatch[2]) || 0;
+                    pathData = svgpath(pathData).translate(x, y).round(floatPrecision).toString();
+                }
+            }
+            elem.addAttr({ name: 'd', value: pathData, prefix: '', local: 'd' });
         });
     }
 
@@ -268,74 +336,6 @@ JS2XML.prototype.refactorData = function(data, floatPrecision, fillBlack) {
                     });
                 }
             }
-        });
-    }
-
-    // Rounded rect to path, SVGO does not convert round rect to paths.
-    let elemRects = data.querySelectorAll('rect');
-    if (elemRects) {
-        elemRects.forEach(elem => {
-            elem.renameElem('path');
-            let x = elem.hasAttr('x') ? parseFloat(elem.attr('x').value) : 0;
-            let y = elem.hasAttr('y') ? parseFloat(elem.attr('y').value) : 0;
-            let width = elem.hasAttr('width') ? parseFloat(elem.attr('width').value) : 0;
-            let height = elem.hasAttr('height') ? parseFloat(elem.attr('height').value) : 0;
-            let rx = 0;
-            let ry = 0;
-            // see spec here: https://www.w3.org/TR/SVG11/shapes.html#RectElement
-            if (elem.hasAttr('rx') && elem.hasAttr('ry')) {
-                rx = parseFloat(elem.attr('rx').value);
-                ry = parseFloat(elem.attr('ry').value);
-            }
-            else if (elem.hasAttr('rx')) {
-                rx = parseFloat(elem.attr('rx').value);
-                ry = rx;
-            }
-            else if (elem.hasAttr('ry')) {
-                ry = parseFloat(elem.attr('ry').value);
-                rx = ry;
-            }
-            x = this.round(x, floatPrecision);
-            y = this.round(y, floatPrecision);
-            width = this.round(width, floatPrecision);
-            height = this.round(height, floatPrecision);
-            rx = this.round(rx, floatPrecision);
-            ry = this.round(ry, floatPrecision);
-            let pathData = this.rectToPathData(x, y, width, height, rx, ry);
-            // Android 8- have a bug when drawing rounded rectangle with arc code in path data.
-            if (rx !== 0 || ry !== 0) {
-                pathData = svgpath(pathData).unarc().rel().round(floatPrecision).toString();
-            }
-
-            // Apply transform to rect.
-            if (elem.hasAttr('transform')) {
-                let svgTransform = elem.attr('transform').value;
-                let number = '((?:-)?\\d+(?:\\.\\d+)?)';
-                let separator = '(?:(?:\\s+)|(?:\\s*,\\s*))';
-                let translateRegExp = new RegExp(`translate\\(${number}${separator}?${number}?\\)`);
-                let scaleRegExp = new RegExp(`scale\\(${number}${separator}?${number}?\\)`);
-                let rotateRegExp = new RegExp(`rotate\\(${number}${separator}?${number}?${separator}?${number}?\\)`);
-                let translateMatch = translateRegExp.exec(svgTransform);
-                let scaleMatch = scaleRegExp.exec(svgTransform);
-                let rotateMatch = rotateRegExp.exec(svgTransform);
-                if (rotateMatch) {
-                    let angle = parseFloat(rotateMatch[1]);
-                    let rx = parseFloat(rotateMatch[2]) || 0;
-                    let ry = parseFloat(rotateMatch[3]) || 0;
-                    pathData = svgpath(pathData).rotate(angle, rx, ry).round(floatPrecision).toString();
-                }
-                if (scaleMatch) {
-                    let sx = parseFloat(scaleMatch[1]);
-                    let sy = parseFloat(scaleMatch[2]) || sx;
-                    pathData = svgpath(pathData).scale(sx, sy).round(floatPrecision).toString();
-                }
-                if (translateMatch) {
-                    let x = parseFloat(translateMatch[1]);
-                    let y = parseFloat(translateMatch[2]) || 0;
-                    pathData = svgpath(pathData).translate(x, y).round(floatPrecision).toString();
-                }
-            }
-            elem.addAttr({ name: 'd', value: pathData, prefix: '', local: 'd' });
         });
     }
 

--- a/test/svgo-to-vectordrawable-test.js
+++ b/test/svgo-to-vectordrawable-test.js
@@ -38,7 +38,7 @@ describe('svg-to-vectordrawable', function() {
                 '        android:pathData="M10 5a5 5 0 1 0 0 10a5 5 0 1 0 0-10z"/>\n' +
                 '</vector>\n')});
     });
-  
+
     it('Does not reject on group masks.', async () => {
         await svg2vectordrawable(`
             <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
@@ -58,9 +58,9 @@ describe('svg-to-vectordrawable', function() {
             <svg width="24" height="24" viewBox="0 0 24 24">
                 <path d="M5 5h5v5H5z"/>
             </svg>
-        `, 
-        undefined, 
-        undefined, 
+        `,
+        undefined,
+        undefined,
         true, // blackDefault
         ).then(function(vd) { expect(vd).toEqual(
             '<vector xmlns:android="http://schemas.android.com/apk/res/android"\n' +
@@ -68,8 +68,8 @@ describe('svg-to-vectordrawable', function() {
             '    android:height="24dp"\n' +
             '    android:viewportWidth="24"\n' +
             '    android:viewportHeight="24">\n' +
-            '    <path\n' + 
-            '        android:fillColor="#000"\n' +  
+            '    <path\n' +
+            '        android:fillColor="#000"\n' +
             '        android:pathData="M5 5h5v5H5z"/>\n' +
             '</vector>\n')});
 
@@ -84,7 +84,7 @@ describe('svg-to-vectordrawable', function() {
             '    android:height="24dp"\n' +
             '    android:viewportWidth="24"\n' +
             '    android:viewportHeight="24">\n' +
-            '    <path\n' +  
+            '    <path\n' +
             '        android:pathData="M5 5h5v5H5z"/>\n' +
             '</vector>\n')});
     });
@@ -119,5 +119,27 @@ describe('svg-to-vectordrawable', function() {
                 </svg>
             `);
         });
+    });
+
+    it('applies group attributes correctly to rounded rectangles', function() {
+        return svg2vectordrawable('<svg>\n' +
+                '<g transform="scale(0.5 0.5) translate(10 10)" fill="#000000" fill-rule="nonzero">\n' +
+            '       <rect x="0" y="0" width="10" height="10" rx="4" />\n' +
+            '       <rect x="0" y="0" width="10" height="10" rx="4" />\n' +
+            '   </g>\n' +
+            '</svg>')
+            .then(function(vd) { expect(vd).toEqual(
+                '<vector xmlns:android="http://schemas.android.com/apk/res/android"\n' +
+                '    android:width="24dp"\n' +
+                '    android:height="24dp"\n' +
+                '    android:viewportWidth="24"\n' +
+                '    android:viewportHeight="24">\n' +
+                '    <path\n' +
+                '        android:fillColor="#000"\n' +
+                '        android:pathData="M0 4c0-2.21 1.79-4 4-4h2c2.21 0 4 1.79 4 4v2c0 2.21-1.79 4-4 4h-2c-2.21 0-4-1.79-4-4z"/>\n' +
+                '    <path\n' +
+                '        android:fillColor="#000"\n' +
+                '        android:pathData="M0 4c0-2.21 1.79-4 4-4h2c2.21 0 4 1.79 4 4v2c0 2.21-1.79 4-4 4h-2c-2.21 0-4-1.79-4-4z"/>\n' +
+                '</vector>\n')});
     });
 });


### PR DESCRIPTION
### Change

Move the block that transforms rounded rectangles into paths
*before* the block that applies gropu attributes to paths. This
ensures that group attributes like "fill" are correctly applied
to the rounded rectangle path elements. No logic was changed,
the code blocks were re-ordered only.

### Testing

Wrote a test, confirmed that it failed because a group fill color was not applied to rounded rectangles in the group, applied my fix, and confirmed that all tests passed.

Fixes #48 