### PR TITLE
Handle gradient initial stop color

### DIFF
--- a/lib/svg-to-vectordrawable.js
+++ b/lib/svg-to-vectordrawable.js
@@ -520,7 +520,8 @@ JS2XML.prototype.addGradientToElement = function(gradient, elem, floatPrecision)
     // Color stops
     gradient.content.forEach(item => {
         let colorStop = new JSAPI({ elem: 'item' });
-        let color = this.svgHexToAndroid(item.attr('stop-color').value);
+        const stopColorAttr = item.attr('stop-color');
+        let color = this.svgHexToAndroid(stopColorAttr == null ? '#000' : stopColorAttr.value);
         const offsetAttr = item.attr('offset');
         let offset = offsetAttr == null ? 0 : offsetAttr.value;
         if (this.isPercent(offset)) {

--- a/test/svgo-to-vectordrawable-test.js
+++ b/test/svgo-to-vectordrawable-test.js
@@ -142,4 +142,18 @@ describe('svg-to-vectordrawable', function() {
                 '        android:pathData="M0 4c0-2.21 1.79-4 4-4h2c2.21 0 4 1.79 4 4v2c0 2.21-1.79 4-4 4h-2c-2.21 0-4-1.79-4-4z"/>\n' +
                 '</vector>\n')});
     });
+
+    it('Handles gradient inital stop color', async () => {
+        await svg2vectordrawable(`
+            <svg width="240" height="240" viewBox="0 0 240 240" xmlns="http://www.w3.org/2000/svg">
+                <path d="M 0 0 H 240 V 240 H 0 Z" fill="url(#paint)"/>
+                <defs>
+                    <linearGradient id="paint" x1="0" y1="0" x2="240" y2="240" gradientUnits="userSpaceOnUse">
+                        <stop stop-color="#636363"/>
+                        <stop offset="1"/>
+                    </linearGradient>
+                </defs>
+            </svg>
+        `);
+    });
 });


### PR DESCRIPTION
Gradient tag may have no stop-color property. In that case initial value is black color.
This pull request fixes the crash.
https://www.w3.org/TR/SVG11/pservers.html#StopColorProperty