### PR TITLE
fillBlack false by default

### DIFF
--- a/src/coa.js
+++ b/src/coa.js
@@ -134,7 +134,7 @@ module.exports = require('coa').Cmd()
         let options = {
             floatPrecision: opts.precision, 
             strict: false, 
-            fillBlack: true,
+            fillBlack: false,
             xmlTag: opts.xmlTag ? true : false,
             tint: opts.tint
         };


### PR DESCRIPTION
The docs state that `fillBlack` is false by default but is not the case if run from command line. The PR fixes it