### PR TITLE
fix issue where plugin tried to call .replace on undefined value

### DIFF
--- a/src/svg-to-vectordrawable.js
+++ b/src/svg-to-vectordrawable.js
@@ -92,9 +92,6 @@ JS2XML.prototype.refactorData = async function(data, floatPrecision, fillBlack, 
         },
         plugins: [
             {
-                name: 'cleanupAttrs'
-            },
-            {
                 name: 'mergeStyles'
             },
             {
@@ -261,6 +258,9 @@ JS2XML.prototype.refactorData = async function(data, floatPrecision, fillBlack, 
             {
                 name: 'reusePaths',
                 active: false
+            },
+            {
+                name: 'cleanupAttrs'
             }
         ]
     };


### PR DESCRIPTION
Encountered an issue where the plugin "cleanupAttrs" from svgo was trying to call `.replace` on a value which was undefined.
Putting this plugin at the end of the plugin list seems to resolve this issue.

```
node_modules/svgo/plugins/cleanupAttrs.js:33
            node.attributes[name] = node.attributes[name].replace(
                                                          ^

TypeError: Cannot read property 'replace' of undefined
    at Object.enter (node_modules/svgo/plugins/cleanupAttrs.js:33:59)
    at visit (node_modules/svgo/lib/xast.js:68:30)
    at visit (node_modules/svgo/lib/xast.js:84:9)
    at visit (node_modules/svgo/lib/xast.js:84:9)
    at visit (node_modules/svgo/lib/xast.js:77:7)
    at invokePlugins (node_modules/svgo/lib/svgo/plugins.js:38:11)
    at JS2XML.refactorData (node_modules/svg2vectordrawable/src/svg-to-vectordrawable.js:330:9)
    at JS2XML.convert (node_modules/svg2vectordrawable/src/svg-to-vectordrawable.js:886:10)
    at node_modules/svg2vectordrawable/src/svg-to-vectordrawable.js:1044:36
    at new Promise (<anonymous>)
    ```