### PR TITLE
Fix error on empty SVG

### DIFF
--- a/src/svg-to-vectordrawable.js
+++ b/src/svg-to-vectordrawable.js
@@ -83,7 +83,7 @@ let JS2XML = function() {
     ];
 };
 
-JS2XML.prototype.refactorData = async function(data, floatPrecision, fillBlack, tint) {
+JS2XML.prototype.refactorData = function(data, floatPrecision, fillBlack, tint) {
 
     // SVGO plugins config
     const svgoConfig = {
@@ -301,9 +301,11 @@ JS2XML.prototype.refactorData = async function(data, floatPrecision, fillBlack, 
     // Remove id attribute in some elements.
     // SVGO do not move transform from group to child elements which have id attribute.
     let elemHaveIds = data.querySelectorAll('path, g, circle, ellipse, line, polygon, polyline, rect');
-    elemHaveIds.forEach(elem => {
-        elem.removeAttr('id');
-    });
+    if (elemHaveIds) {
+        elemHaveIds.forEach(elem => {
+            elem.removeAttr('id');
+        });
+    }
 
     // SVG Optimize use SVGO
     const plugins = svgoConfig.plugins || defaultPlugins;

--- a/test/svgo-to-vectordrawable-test.js
+++ b/test/svgo-to-vectordrawable-test.js
@@ -30,6 +30,16 @@ describe('svg-to-vectordrawable', function() {
         );
     });
 
+    it('supports empty svgs', function() {
+        return svg2vectordrawable('<svg></svg>')
+            .then(function(vd) { expect(vd).toEqual(`<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"/>
+`)});
+    });
+
     it('supports groups with multiple transforms', function() {
         return svg2vectordrawable(`<svg>
                 <g transform="scale(0.5 0.5) translate(10 10)">


### PR DESCRIPTION
Fixes issue where the library would throw an error on empty SVG input.

Also removes unnecessary async from the data cleanup function as it makes handling future errors in the function harder.