### PR TITLE
fix unnecessary strict mode unsupported errors

### DIFF
--- a/src/svg-to-vectordrawable.js
+++ b/src/svg-to-vectordrawable.js
@@ -407,6 +407,12 @@ JS2XML.prototype.refactorData = function(data, floatPrecision, fillBlack, tint) 
                 }
             }
             elem.addAttr({ name: 'd', value: pathData, prefix: '', local: 'd' });
+            elem.removeAttr('x')
+            elem.removeAttr('y')
+            elem.removeAttr('width')
+            elem.removeAttr('height')
+            elem.removeAttr('rx')
+            elem.removeAttr('ry')
         });
     }
 
@@ -609,6 +615,9 @@ JS2XML.prototype.refactorData = function(data, floatPrecision, fillBlack, tint) 
                     });
                 }
             }
+
+            // Remove original gradient element
+            gradient.parentNode.spliceContent(gradient.parentNode.children.indexOf(gradient), 1, []);
         });
     }
 
@@ -639,6 +648,9 @@ JS2XML.prototype.refactorData = function(data, floatPrecision, fillBlack, tint) 
                 });
                 elem.parentNode.spliceContent(elem.parentNode.children.indexOf(maskedElems[0]), maskedElems.length, maskGroup);
             }
+
+            // Remove original mask element
+            elem.parentNode.spliceContent(elem.parentNode.children.indexOf(elem), 1, []);
         });
     }
 
@@ -648,7 +660,10 @@ JS2XML.prototype.refactorData = function(data, floatPrecision, fillBlack, tint) 
         elemPaths.forEach(elem => {
             // Fill
             if (elem.hasAttr('fill')) {
-                if (!/^url\(#.*\)$/.test(elem.attr('fill').value) && elem.attr('fill').value !== 'none') {
+                if (elem.attr('fill').value === 'none') {
+                    elem.removeAttr('fill');
+                }
+                else if (!/^url\(#.*\)$/.test(elem.attr('fill').value)) {
                     let color = this.svgHexToAndroid(elem.attr('fill').value);
                     let fillAttr = { name: 'android:fillColor', value: color, prefix: 'android', local: 'fillColor' };
                     if (elem.hasAttr('fill-opacity')) {
@@ -740,9 +755,11 @@ JS2XML.prototype.addGradientToElement = function(gradient, elem, floatPrecision)
     let gradientId = gradient.attr('id').value;
     if (elem.hasAttr('fill', `url(#${gradientId})`)) {
         vectorDrawableAapt.addAttr({ name: 'name', value: 'android:fillColor', prefix: '', local: 'name'})
+        elem.removeAttr('fill')
     }
     if (elem.hasAttr('stroke', `url(#${gradientId})`)) {
         vectorDrawableAapt.addAttr({ name: 'name', value: 'android:strokeColor', prefix: '', local: 'name'})
+        elem.removeAttr('stroke')
     }
 
     this.adjustGradientCoordinate(gradient, elem, floatPrecision);

--- a/test/svgo-to-vectordrawable-test.js
+++ b/test/svgo-to-vectordrawable-test.js
@@ -13,7 +13,36 @@ describe('svg-to-vectordrawable', function() {
     });
 
     it('resolves in strict mode when all elements and attributes are supported', function() {
-        return svg2vectordrawable('<svg><rect width="10" height="10" /></svg>', { strict: true });
+        return svg2vectordrawable(`<svg height="100" width="100" x="10" y="10" viewBox="0 0 100 100">
+                <g>
+                    <circle cx="54" cy="54" r="35" fill="#888" />
+                    <ellipse cx="54" cy="54" rx="35" ry="5" fill="#11223344" />
+                    <line x1="5" y1="5" x2="10" y2="5" fill="red" opacity="0.7" />
+                    <polygon points="0,0 0,10 10,0 10,10" stroke="red" />
+                    <polyline points="0,0 0,10 10,0 10,10" stroke="blue" fill="none" />
+                    <rect x="5" y="5" width="10" height="10" rx="2" ry="2" stroke="#888" opacity="0.5" />
+                </g>
+
+                <linearGradient id="linearGradient" gradientTransform="rotate(90)">
+                    <stop offset="5%" stop-color="gold" stop-opacity="0.5" />
+                    <stop offset="95%" stop-color="red" />
+                </linearGradient>
+                <radialGradient id="radialGradient">
+                    <stop offset="10%" stop-color="gold" />
+                    <stop offset="95%" stop-color="red" stop-opacity="0.5" />
+                </radialGradient>
+                <mask id="mask">
+                    <rect x="0" y="0" width="100" height="100" fill="white" />
+                </mask>
+
+                <g>
+                    <circle cx="20" cy="20" r="10" fill="url(#linearGradient)"/>
+                    <circle cx="20" cy="20" r="10" fill="url(#radialGradient)" />
+                    <circle cx="20" cy="20" r="10" mask="url(#mask)" />                
+                </g>
+            </svg>`,
+            { strict: true },
+        );
     });
 
     it('rejects in strict mode on no supported elements', function() {


### PR DESCRIPTION
Noticed that the `strict` mode would in some scenarios reject SVG inputs that should be supported by vector drawables. These were for example elements with `fill="none"`, or rounded `rect` elements.

This PR extends the strict mode test with more elements and attributes, and fixes the bugs that caused the test to fail.